### PR TITLE
refactor: separate input types

### DIFF
--- a/src/app/course/course-search-helper/course-search-helper.component.html
+++ b/src/app/course/course-search-helper/course-search-helper.component.html
@@ -24,58 +24,23 @@
     <mat-error>請選擇比對方式</mat-error>
   </mat-form-field>
 
-  <mat-form-field class="grow">
-    <mat-label>比對內容</mat-label>
-
-    <mat-chip-grid
-      #chipGrid
-      aria-label="Content Selection"
-      [disabled]="!provider"
-    >
-      <ng-container *ngFor="let selected of query.value; let index = index">
-        <span class="inline-block self-center" *ngIf="index > 0">或</span>
-        <mat-chip-row (removed)="removeSelectedOption(index)">
-          {{ selected.label }}
-          <button matChipRemove [attr.aria-label]="'remove ' + selected">
-            <mat-icon>cancel</mat-icon>
-          </button>
-        </mat-chip-row>
-      </ng-container>
-    </mat-chip-grid>
-
-    <input
-      matInput
-      type="text"
-      placeholder="輸入來過濾或選擇"
-      (focus)="methodSelect._onBlur()"
-      [matAutocomplete]="auto"
-      [matAutocompleteDisabled]="provider?.type === 'text'"
-      [matChipInputFor]="chipGrid"
-      [matChipInputAddOnBlur]="provider?.type === 'text'"
-      (matChipInputTokenEnd)="addText($event)"
-      [matChipInputSeparatorKeyCodes]="separatorKeyCodes"
-      [formControl]="inputControl"
-      [value]="inputControl.value"
-    />
-    <mat-error>{{ error }}</mat-error>
-
-    <mat-autocomplete
-      #auto="matAutocomplete"
-      autoActiveFirstOption
-      autoSelectActiveOption
-      (opened)="bindLoadingTrigger()"
-      (optionSelected)="selectOption($event)"
-    >
-      <mat-option *ngFor="let option of options" [value]="option">
-        {{ option.label }}
-      </mat-option>
-      <mat-progress-bar
-        mode="indeterminate"
-        *ngIf="isLoadingOptions"
-      ></mat-progress-bar>
-      <mat-option class="loading-trigger" disabled></mat-option>
-    </mat-autocomplete>
-  </mat-form-field>
+  <app-text-input
+    class="grow"
+    *ngIf="provider?.type === 'text'"
+    [provider]="provider"
+    [value]="query.value"
+    (active)="methodSelect._onBlur()"
+    (updated)="valueUpdated($event)"
+  ></app-text-input>
+  <app-select-input
+    class="grow"
+    *ngIf="provider?.type === 'select'"
+    [provider]="provider"
+    [providerChange]="providerChange.asObservable()"
+    [value]="query.value"
+    (active)="methodSelect._onBlur()"
+    (updated)="valueUpdated($event)"
+  ></app-select-input>
 
   <button
     mat-icon-button

--- a/src/app/course/course-search-helper/course-search-helper.component.ts
+++ b/src/app/course/course-search-helper/course-search-helper.component.ts
@@ -1,9 +1,5 @@
-import { ENTER, SPACE } from "@angular/cdk/keycodes";
-import { Component, Input, OnInit, ViewChild } from "@angular/core";
-import { FormControl } from "@angular/forms";
-import { MatAutocompleteSelectedEvent } from "@angular/material/autocomplete";
-import { MatChipGrid, MatChipInputEvent } from "@angular/material/chips";
-import { interval, Subscription, take } from "rxjs";
+import { Component, Input, OnInit } from "@angular/core";
+import { Subject } from "rxjs";
 
 import { Displayable } from "../../_types/displayable";
 import { CourseQueryService } from "../_query/course-query.service";
@@ -29,8 +25,6 @@ export class CourseSearchHelperComponent implements OnInit {
   provider?: QueryDataProvider;
   /** All selectable compare methods, will be undefined or null when no provider */
   methods?: Displayable[];
-  /** All selectable options, will be empty array when text */
-  options: Displayable[] = [];
 
   constructor(private courseQueryService: CourseQueryService) {}
 
@@ -40,33 +34,6 @@ export class CourseSearchHelperComponent implements OnInit {
       .map(provider => ({ key: provider.key, label: provider.label }));
     this.query = this.courseQueryService.getQuery(this.index);
     if (this.query.key) this.setProvider(this.query.key, false);
-
-    // listen to value change to filter selectable options
-    this.inputControl.valueChanges.subscribe(() =>
-      this.inputValueChangeHandler(),
-    );
-  }
-
-  /** Subscription of user idle detector */
-  whenIdleSubscription?: Subscription;
-
-  /**
-   * Handler when input value changed, will trigger option fetch when user stop typing for 500ms
-   */
-  inputValueChangeHandler(): void {
-    this.setInputError(null);
-    if (this.provider?.type === "text") return;
-
-    this.whenIdleSubscription?.unsubscribe();
-    this.whenIdleSubscription = interval(500)
-      .pipe(take(1))
-      .subscribe(() => {
-        this.whenIdleSubscription?.unsubscribe();
-        this.whenIdleSubscription = undefined;
-        this.optionsPage = 0;
-        this.options = [];
-        this.getOptions(this.inputControl.value ?? "");
-      });
   }
 
   /**
@@ -83,8 +50,7 @@ export class CourseSearchHelperComponent implements OnInit {
     }
     this.provider = this.courseQueryService.getProvider(providerKey);
     this.methods = this.provider?.getMethods();
-    this.options = [];
-    this.optionsPage = 0;
+    this.providerChange.next();
   }
 
   /**
@@ -94,136 +60,22 @@ export class CourseSearchHelperComponent implements OnInit {
     this.courseQueryService.setQuery(this.index, this.query);
   }
 
+  /** notify child components that provider has changed */
+  providerChange: Subject<void> = new Subject<void>();
+
+  /**
+   * Update value after child component emit value updated event
+   * @param value emitted value from input sub component
+   */
+  valueUpdated(value: Displayable[]) {
+    this.query.value = value;
+    this.notifyQueryUpdate();
+  }
+
   /**
    * Remove this whole query from queries list
    */
   removeQuery() {
     this.courseQueryService.removeQuery(this.index);
-  }
-
-  /** Key codes that is be used to separate words in text input chips mode */
-  separatorKeyCodes = [SPACE, ENTER];
-  /** Input of value */
-  inputControl = new FormControl("");
-
-  @ViewChild("chipGrid") chipGrid!: MatChipGrid;
-  error: string | null = null;
-
-  /**
-   * Set input error to display or clear error
-   * @param error error message to set, if null, will clear error
-   */
-  setInputError(error: string | null) {
-    this.chipGrid.errorState = !!error;
-    this.error = error;
-  }
-
-  /**
-   * Add text in input to query value and clear input
-   * @param event event of input sent by MatChipInput
-   */
-  addText(event: MatChipInputEvent): void {
-    if (this.provider?.type !== "text") return;
-
-    const value = event.value.trim();
-    if (value === "") return;
-
-    const error = this.provider.getValidationResult(value);
-    this.setInputError(error);
-    if (error) return;
-
-    if (!this.query.value) this.query.value = [];
-    this.query.value.push({
-      key: event.value.trim(),
-      label: event.value.trim(),
-    });
-    this.inputControl.setValue("");
-    this.notifyQueryUpdate();
-  }
-
-  /** Is waiting for server respond options or not */
-  isLoadingOptions = false;
-  /** Visibility detector, used to additional loading options */
-  intersectionObserver = new IntersectionObserver(
-    entries => {
-      // observer will be triggered when target is going to visible or invisible
-      // so we have to ignore invisible event
-      if (!entries[0].isIntersecting) return;
-      if (this.optionsPage < 0) return;
-
-      this.isLoadingOptions = true;
-      // Stop observing while loading options
-      this.intersectionObserver.disconnect();
-      this.getOptions(this.inputControl.value ?? "");
-    },
-    { threshold: 1 },
-  );
-
-  /**
-   * Bind intersection observer to element that is preserved in options menu
-   */
-  bindLoadingTrigger(): void {
-    const target = document.querySelector(
-      ".mat-mdc-autocomplete-panel .loading-trigger",
-    );
-    if (!target) return;
-    this.intersectionObserver.disconnect();
-    this.intersectionObserver.unobserve(target);
-    this.intersectionObserver.observe(target);
-  }
-
-  /** Current page of options, needs to be reset when searching context changed */
-  optionsPage = 0;
-  /** Last query request, used to cancel last request when new request is triggered */
-  lastQueryRequest?: Subscription;
-
-  /**
-   * Get options from server
-   * @param value value to search options
-   */
-  getOptions(value: string): void {
-    this.lastQueryRequest?.unsubscribe();
-    this.lastQueryRequest = this.provider
-      ?.getOptions({
-        page: this.optionsPage + 1,
-        keyword: value.trim(),
-      })
-      .subscribe(options => {
-        this.options.push(
-          ...options.content.filter(option => {
-            return !this.query.value?.find(
-              selected => selected.key === option.key,
-            );
-          }),
-        );
-        this.optionsPage = options.pagination.current;
-        this.isLoadingOptions = false;
-        if (options.pagination.current >= options.pagination.total) {
-          this.optionsPage = -1;
-          return;
-        }
-        this.bindLoadingTrigger();
-      });
-  }
-
-  /**
-   * Select an option into query value and remove it from options list
-   * @param event event of option selected
-   */
-  selectOption(event: MatAutocompleteSelectedEvent): void {
-    if (!this.query.value) this.query.value = [];
-    this.query.value.push(event.option.value);
-    this.options.splice(this.options.indexOf(event.option.value), 1);
-    this.inputControl.setValue("");
-    this.notifyQueryUpdate();
-  }
-
-  /**
-   * Remove selected option from query value
-   * @param index index of selected option to remove
-   */
-  removeSelectedOption(index: number): void {
-    this.query.value?.splice(index, 1);
-    this.notifyQueryUpdate();
   }
 }

--- a/src/app/course/course-search-helper/course-search-helper.module.ts
+++ b/src/app/course/course-search-helper/course-search-helper.module.ts
@@ -11,9 +11,15 @@ import { MatProgressBarModule } from "@angular/material/progress-bar";
 import { MatSelectModule } from "@angular/material/select";
 
 import { CourseSearchHelperComponent } from "./course-search-helper.component";
+import { SelectInputComponent } from "./select-input/select-input.component";
+import { TextInputComponent } from "./text-input/text-input.component";
 
 @NgModule({
-  declarations: [CourseSearchHelperComponent],
+  declarations: [
+    CourseSearchHelperComponent,
+    TextInputComponent,
+    SelectInputComponent,
+  ],
   imports: [
     CommonModule,
     FormsModule,

--- a/src/app/course/course-search-helper/select-input/select-input.component.css
+++ b/src/app/course/course-search-helper/select-input/select-input.component.css
@@ -1,0 +1,11 @@
+mat-form-field {
+  @apply block !important;
+}
+
+mat-chip-row {
+  @apply mx-1 !important;
+}
+
+.loading-trigger {
+  min-height: 0;
+}

--- a/src/app/course/course-search-helper/select-input/select-input.component.html
+++ b/src/app/course/course-search-helper/select-input/select-input.component.html
@@ -1,0 +1,49 @@
+<mat-form-field>
+  <mat-label>比對內容</mat-label>
+
+  <mat-chip-grid
+    #chipGrid
+    aria-label="Content Selection"
+    [disabled]="!provider"
+  >
+    <ng-container *ngFor="let selected of value; let index = index">
+      <span class="inline-block self-center" *ngIf="index > 0">或</span>
+      <mat-chip-row (removed)="removeSelectedOption(index)">
+        {{ selected.label }}
+        <button matChipRemove [attr.aria-label]="'remove ' + selected">
+          <mat-icon>cancel</mat-icon>
+        </button>
+      </mat-chip-row>
+    </ng-container>
+  </mat-chip-grid>
+
+  <input
+    matInput
+    type="text"
+    placeholder="輸入來過濾或選擇"
+    (focus)="active.emit()"
+    [matAutocomplete]="auto"
+    [matAutocompleteDisabled]="provider?.type !== 'select'"
+    [matChipInputFor]="chipGrid"
+    [formControl]="inputControl"
+    [value]="inputControl.value"
+  />
+  <mat-error>{{ error }}</mat-error>
+
+  <mat-autocomplete
+    #auto="matAutocomplete"
+    autoActiveFirstOption
+    autoSelectActiveOption
+    (opened)="bindLoadingTrigger()"
+    (optionSelected)="selectOption($event)"
+  >
+    <mat-option *ngFor="let option of options" [value]="option">
+      {{ option.label }}
+    </mat-option>
+    <mat-progress-bar
+      mode="indeterminate"
+      *ngIf="isLoadingOptions"
+    ></mat-progress-bar>
+    <mat-option class="loading-trigger" disabled></mat-option>
+  </mat-autocomplete>
+</mat-form-field>

--- a/src/app/course/course-search-helper/select-input/select-input.component.spec.ts
+++ b/src/app/course/course-search-helper/select-input/select-input.component.spec.ts
@@ -1,0 +1,41 @@
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { FormsModule, ReactiveFormsModule } from "@angular/forms";
+import { MatAutocompleteModule } from "@angular/material/autocomplete";
+import { MatChipsModule } from "@angular/material/chips";
+import { MatFormFieldModule } from "@angular/material/form-field";
+import { MatIconModule } from "@angular/material/icon";
+import { MatInputModule } from "@angular/material/input";
+import { MatSelectModule } from "@angular/material/select";
+import { NoopAnimationsModule } from "@angular/platform-browser/animations";
+
+import { SelectInputComponent } from "./select-input.component";
+
+describe("SelectInputComponent", () => {
+  let component: SelectInputComponent;
+  let fixture: ComponentFixture<SelectInputComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [SelectInputComponent],
+      imports: [
+        NoopAnimationsModule,
+        FormsModule,
+        ReactiveFormsModule,
+        MatFormFieldModule,
+        MatSelectModule,
+        MatIconModule,
+        MatAutocompleteModule,
+        MatInputModule,
+        MatChipsModule,
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SelectInputComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it("should create", () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/course/course-search-helper/select-input/select-input.component.ts
+++ b/src/app/course/course-search-helper/select-input/select-input.component.ts
@@ -1,0 +1,172 @@
+import {
+  Component,
+  EventEmitter,
+  Input,
+  OnInit,
+  Output,
+  ViewChild,
+} from "@angular/core";
+import { FormControl } from "@angular/forms";
+import { MatAutocompleteSelectedEvent } from "@angular/material/autocomplete";
+import { MatChipGrid } from "@angular/material/chips";
+import { interval, Observable, Subscription, take } from "rxjs";
+
+import { Displayable } from "../../../_types/displayable";
+import { QueryDataProvider } from "../../_query/query-data-provider";
+
+@Component({
+  selector: "app-select-input",
+  templateUrl: "./select-input.component.html",
+  styleUrls: ["./select-input.component.css"],
+})
+export class SelectInputComponent implements OnInit {
+  /** An event emitter that emit events when input has been focused */
+  @Output() active: EventEmitter<void> = new EventEmitter();
+  /** An event emitter that emit events when value has been updated */
+  @Output() updated: EventEmitter<Displayable[]> = new EventEmitter();
+  /** Data provider of current filtering condition */
+  @Input() provider?: QueryDataProvider;
+  /** Value of current filtering condition */
+  @Input() value?: Displayable[] = [];
+  /** Writable value */
+  private localValue: Displayable[] = [];
+  /** An event emitter that receive event from parent when provider changed */
+  @Input() providerChange?: Observable<void>;
+  /** Selectable options */
+  options: Displayable[] = [];
+
+  ngOnInit() {
+    this.providerChange?.subscribe(() => {
+      this.optionsPage = 0;
+      this.options = [];
+    });
+
+    // listen to value change to filter selectable options
+    this.inputControl.valueChanges.subscribe(() =>
+      this.inputValueChangeHandler(),
+    );
+  }
+
+  /** Subscription of user idle detector */
+  whenIdleSubscription?: Subscription;
+
+  /**
+   * Handler when input value changed, will trigger option fetch when user stop typing for 500ms
+   */
+  inputValueChangeHandler(): void {
+    this.setInputError(null);
+
+    this.whenIdleSubscription?.unsubscribe();
+    this.whenIdleSubscription = interval(500)
+      .pipe(take(1))
+      .subscribe(() => {
+        this.whenIdleSubscription?.unsubscribe();
+        this.whenIdleSubscription = undefined;
+        this.optionsPage = 0;
+        this.options = [];
+        this.getOptions(this.inputControl.value ?? "");
+      });
+  }
+
+  notifyQueryUpdate() {
+    this.updated.emit(this.localValue);
+  }
+
+  /** Input of value */
+  inputControl = new FormControl("");
+
+  @ViewChild("chipGrid") chipGrid!: MatChipGrid;
+  error: string | null = null;
+
+  /**
+   * Set input error to display or clear error
+   * @param error error message to set, if null, will clear error
+   */
+  setInputError(error: string | null) {
+    this.chipGrid.errorState = !!error;
+    this.error = error;
+  }
+
+  /** Is waiting for server respond options or not */
+  isLoadingOptions = false;
+  /** Visibility detector, used to additional loading options */
+  intersectionObserver = new IntersectionObserver(
+    entries => {
+      // observer will be triggered when target is going to visible or invisible
+      // so we have to ignore invisible event
+      if (!entries[0].isIntersecting) return;
+      if (this.optionsPage < 0) return;
+
+      this.isLoadingOptions = true;
+      // Stop observing while loading options
+      this.intersectionObserver.disconnect();
+      this.getOptions(this.inputControl.value ?? "");
+    },
+    { threshold: 1 },
+  );
+
+  /**
+   * Bind intersection observer to element that is preserved in options menu
+   */
+  bindLoadingTrigger(): void {
+    const target = document.querySelector(
+      ".mat-mdc-autocomplete-panel .loading-trigger",
+    );
+    if (!target) return;
+    this.intersectionObserver.disconnect();
+    this.intersectionObserver.unobserve(target);
+    this.intersectionObserver.observe(target);
+  }
+
+  /** Current page of options, needs to be reset when searching context changed */
+  optionsPage = 0;
+  /** Last query request, used to cancel last request when new request is triggered */
+  lastQueryRequest?: Subscription;
+
+  /**
+   * Get options from server
+   * @param value value to search options
+   */
+  getOptions(value: string): void {
+    this.lastQueryRequest?.unsubscribe();
+    this.lastQueryRequest = this.provider
+      ?.getOptions({
+        page: this.optionsPage + 1,
+        keyword: value.trim(),
+      })
+      .subscribe(options => {
+        this.options.push(
+          ...options.content.filter(option => {
+            return !this.value?.find(selected => selected.key === option.key);
+          }),
+        );
+        this.optionsPage = options.pagination.current;
+        this.isLoadingOptions = false;
+        if (options.pagination.current >= options.pagination.total) {
+          this.optionsPage = -1;
+          return;
+        }
+        this.bindLoadingTrigger();
+      });
+  }
+
+  /**
+   * Select an option into query value and remove it from options list
+   * @param event event of option selected
+   */
+  selectOption(event: MatAutocompleteSelectedEvent): void {
+    this.localValue?.push(event.option.value);
+    this.options.splice(this.options.indexOf(event.option.value), 1);
+    this.inputControl.setValue("");
+    this.notifyQueryUpdate();
+  }
+
+  /**
+   * Remove selected option from query value
+   * @param index index of selected option to remove
+   */
+  removeSelectedOption(index: number): void {
+    this.localValue?.splice(index, 1);
+    this.notifyQueryUpdate();
+  }
+}

--- a/src/app/course/course-search-helper/text-input/text-input.component.css
+++ b/src/app/course/course-search-helper/text-input/text-input.component.css
@@ -1,0 +1,3 @@
+mat-form-field {
+  display: block !important;
+}

--- a/src/app/course/course-search-helper/text-input/text-input.component.html
+++ b/src/app/course/course-search-helper/text-input/text-input.component.html
@@ -1,0 +1,33 @@
+<mat-form-field>
+  <mat-label>比對內容</mat-label>
+
+  <mat-chip-grid
+    #chipGrid
+    aria-label="Content Selection"
+    [disabled]="!provider"
+  >
+    <ng-container *ngFor="let selected of value; let index = index">
+      <span class="inline-block self-center" *ngIf="index > 0">或</span>
+      <mat-chip-row (removed)="removeSelectedOption(index)">
+        {{ selected.label }}
+        <button matChipRemove [attr.aria-label]="'remove ' + selected">
+          <mat-icon>cancel</mat-icon>
+        </button>
+      </mat-chip-row>
+    </ng-container>
+  </mat-chip-grid>
+
+  <input
+    matInput
+    type="text"
+    placeholder="輸入來過濾或選擇"
+    (focus)="active.emit()"
+    [matChipInputFor]="chipGrid"
+    matChipInputAddOnBlur
+    (matChipInputTokenEnd)="addText($event)"
+    [matChipInputSeparatorKeyCodes]="separatorKeyCodes"
+    [formControl]="inputControl"
+    [value]="inputControl.value"
+  />
+  <mat-error>{{ error }}</mat-error>
+</mat-form-field>

--- a/src/app/course/course-search-helper/text-input/text-input.component.spec.ts
+++ b/src/app/course/course-search-helper/text-input/text-input.component.spec.ts
@@ -1,0 +1,37 @@
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { FormsModule, ReactiveFormsModule } from "@angular/forms";
+import { MatChipsModule } from "@angular/material/chips";
+import { MatFormFieldModule } from "@angular/material/form-field";
+import { MatIconModule } from "@angular/material/icon";
+import { MatInputModule } from "@angular/material/input";
+import { NoopAnimationsModule } from "@angular/platform-browser/animations";
+
+import { TextInputComponent } from "./text-input.component";
+
+describe("TextInputComponent", () => {
+  let component: TextInputComponent;
+  let fixture: ComponentFixture<TextInputComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [TextInputComponent],
+      imports: [
+        NoopAnimationsModule,
+        FormsModule,
+        ReactiveFormsModule,
+        MatFormFieldModule,
+        MatIconModule,
+        MatInputModule,
+        MatChipsModule,
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TextInputComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it("should create", () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/course/course-search-helper/text-input/text-input.component.ts
+++ b/src/app/course/course-search-helper/text-input/text-input.component.ts
@@ -1,0 +1,89 @@
+import { ENTER, SPACE } from "@angular/cdk/keycodes";
+import {
+  Component,
+  EventEmitter,
+  Input,
+  OnInit,
+  Output,
+  ViewChild,
+} from "@angular/core";
+import { FormControl } from "@angular/forms";
+import { MatChipGrid, MatChipInputEvent } from "@angular/material/chips";
+
+import { Displayable } from "../../../_types/displayable";
+import { QueryDataProvider } from "../../_query/query-data-provider";
+
+@Component({
+  selector: "app-text-input",
+  templateUrl: "./text-input.component.html",
+  styleUrls: ["./text-input.component.css"],
+})
+export class TextInputComponent implements OnInit {
+  /** An event emitter that emit events when input has been focused */
+  @Output() active: EventEmitter<void> = new EventEmitter();
+  /** An event emitter that emit events when value has been updated */
+  @Output() updated: EventEmitter<Displayable[]> = new EventEmitter();
+  /** Data provider of current filtering condition */
+  @Input() provider?: QueryDataProvider;
+  /** Value of current filtering condition */
+  @Input() value?: Displayable[] = [];
+  /** Writable value */
+  private localValue: Displayable[] = [];
+
+  ngOnInit(): void {
+    this.inputControl.valueChanges.subscribe(() => this.setInputError(null));
+  }
+
+  notifyQueryUpdate() {
+    this.updated.emit(this.localValue);
+  }
+
+  /** Key codes that is be used to separate words in text input chips mode */
+  separatorKeyCodes = [SPACE, ENTER];
+  /** Input of value */
+  inputControl = new FormControl("");
+
+  @ViewChild("chipGrid") chipGrid!: MatChipGrid;
+  error: string | null = null;
+
+  /**
+   * Set input error to display or clear error
+   * @param error error message to set, if null, will clear error
+   */
+  setInputError(error: string | null) {
+    this.chipGrid.errorState = !!error;
+    this.error = error;
+  }
+
+  /**
+   * Add text in input to query value and clear input
+   * @param event event of input sent by MatChipInput
+   */
+  addText(event: MatChipInputEvent): void {
+    if (this.provider?.type !== "text") return;
+
+    const value = event.value.trim();
+    if (value === "") return;
+
+    const error = this.provider.getValidationResult(value);
+    this.setInputError(error);
+    if (error) return;
+
+    if (!this.localValue) this.localValue = [];
+    this.localValue.push({
+      key: event.value.trim(),
+      label: event.value.trim(),
+    });
+    this.inputControl.setValue("");
+    this.notifyQueryUpdate();
+  }
+
+  /**
+   * Remove selected option from query value
+   * @param index index of selected option to remove
+   */
+  removeSelectedOption(index: number): void {
+    this.localValue?.splice(index, 1);
+    this.notifyQueryUpdate();
+  }
+}


### PR DESCRIPTION
This PR split out text and select input into two components from current component, this change make input replaceable by other components, which is necessary for implement another input type later.