### PR TITLE
refactor: queries serialization

### DIFF
--- a/src/app/course/_query/course-query.service.ts
+++ b/src/app/course/_query/course-query.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from "@angular/core";
+import { ParamMap } from "@angular/router";
 import { BehaviorSubject, Observable } from "rxjs";
 
 import { QueryDataProvider } from "./query-data-provider";
@@ -86,7 +87,7 @@ export class CourseQueryService {
     this.queriesSubject.next(this.queries);
   }
 
-  convertToQueryParams(): { [key: string]: string[] } {
+  serializeQueries(): { [key: string]: string[] } {
     const params: { [key: string]: string[] } = {};
     this.queries.forEach(query => {
       if (!query.key || !query.method || !query.value?.length) return;
@@ -97,5 +98,33 @@ export class CourseQueryService {
     });
 
     return params;
+  }
+
+  async deserializeQueries(
+    paramMap: ParamMap,
+    save = true,
+  ): Promise<QueryItem<unknown>[]> {
+    if (save) this.clearQueries();
+
+    const queries: QueryItem<unknown>[] = [];
+    const queryParsers = this.providers.map(displayable => {
+      const provider = this.getProvider(displayable.value);
+      if (!provider) return;
+      const values = paramMap.getAll(displayable.value);
+
+      const queryParsers = values.map(async value => {
+        queries.push(await provider.parseQuery(value));
+      });
+      return Promise.all(queryParsers);
+    });
+
+    await Promise.all(queryParsers).then(() => this.removeEmptyQueries());
+
+    if (save) {
+      this.queries = queries;
+      this.queriesSubject.next(this.queries);
+    }
+
+    return queries;
   }
 }

--- a/src/app/course/_query/course-query.service.ts
+++ b/src/app/course/_query/course-query.service.ts
@@ -94,7 +94,7 @@ export class CourseQueryService {
       if (!params[query.key]) params[query.key] = [];
       const provider = this.getProvider(query.key);
       if (!provider) return;
-      params[query.key].push(provider.stringifyQuery(query));
+      params[query.key].push(provider.serializeQuery(query));
     });
 
     return params;
@@ -113,7 +113,7 @@ export class CourseQueryService {
       const values = paramMap.getAll(displayable.value);
 
       const queryParsers = values.map(async value => {
-        queries.push(await provider.parseQuery(value));
+        queries.push(await provider.deserializeQuery(value));
       });
       return Promise.all(queryParsers);
     });

--- a/src/app/course/_query/query-data-provider.ts
+++ b/src/app/course/_query/query-data-provider.ts
@@ -38,7 +38,7 @@ export abstract class QueryDataProvider<T = unknown>
    * To stringify the query to a string.
    * @param query The query to be stringify
    */
-  stringifyQuery(query: QueryItem<T>): string {
+  serializeQuery(query: QueryItem<T>): string {
     if (!query.method || !query.value?.length) {
       throw new Error("Invalid query.");
     }
@@ -56,7 +56,7 @@ export abstract class QueryDataProvider<T = unknown>
    * To parse the query from a string.
    * @param query The query to be parse
    */
-  async parseQuery(query: string): Promise<QueryItem<T>> {
+  async deserializeQuery(query: string): Promise<QueryItem<T>> {
     const [method, ...values] = query.split(":");
     const value = await this.deserializeValues(values.join(":"));
 

--- a/src/app/course/_query/query-data-provider.ts
+++ b/src/app/course/_query/query-data-provider.ts
@@ -3,23 +3,28 @@ import { Observable } from "rxjs";
 import { Displayable } from "../../_types/displayable";
 import { QueryItem } from "./query-item";
 
-export interface QueryDataProvider<T = unknown> extends Displayable<string> {
+export abstract class QueryDataProvider<T = unknown>
+  implements Displayable<string>
+{
   /** Separator for values */
-  valueSeparator: string;
+  abstract valueSeparator: string;
 
   /** Type of value */
-  type: QueryDataType;
+  abstract type: QueryDataType;
+
+  abstract value: string;
+  abstract label: string;
 
   /**
    * To get available comparison methods that could be select by user.
    */
-  getMethods(): Displayable<string>[];
+  abstract getMethods(): Displayable<string>[];
 
   /**
    * To get the options for users to select.
    * @param options Options to be passed to the provider
    */
-  getOptions(
+  abstract getOptions(
     options?: CanPaginate | Record<string, unknown>,
   ): Observable<StandardResponse<Displayable<string>[]>>;
 
@@ -27,19 +32,44 @@ export interface QueryDataProvider<T = unknown> extends Displayable<string> {
    * To validate the value is a valid value or not, only for text type.
    * @param value The value to be validate
    */
-  getValidationResult(value: string): string | null;
+  abstract getValidationResult(value: string): string | null;
 
   /**
    * To stringify the query to a string.
    * @param query The query to be stringify
    */
-  stringifyQuery(query: QueryItem<T>): string;
+  stringifyQuery(query: QueryItem<T>): string {
+    if (!query.method || !query.value?.length) {
+      throw new Error("Invalid query.");
+    }
+
+    return query.method + ":" + this.serializeValues(query.value);
+  }
+
+  protected serializeValues(values: Displayable<T>[]): string {
+    return values.map(v => this.serializeValue(v)).join(this.valueSeparator);
+  }
+
+  protected abstract serializeValue(value: Displayable<T>): string;
 
   /**
    * To parse the query from a string.
    * @param query The query to be parse
    */
-  parseQuery(query: string): Promise<QueryItem<T>>;
+  async parseQuery(query: string): Promise<QueryItem<T>> {
+    const [method, ...values] = query.split(":");
+    const value = await this.deserializeValues(values.join(":"));
+
+    return {
+      key: this.value,
+      method,
+      value,
+    };
+  }
+
+  protected abstract deserializeValues(
+    value: string,
+  ): Promise<Displayable<T>[]>;
 }
 
 export enum QueryDataType {

--- a/src/app/course/_query/query-data-providers/code-query-data-provider/code-query-data-provider.service.ts
+++ b/src/app/course/_query/query-data-providers/code-query-data-provider/code-query-data-provider.service.ts
@@ -3,12 +3,11 @@ import { Observable } from "rxjs";
 
 import { Displayable } from "../../../../_types/displayable";
 import { QueryDataProvider, QueryDataType } from "../../query-data-provider";
-import { QueryItem } from "../../query-item";
 
 @Injectable({
   providedIn: "root",
 })
-export class CodeQueryDataProviderService implements QueryDataProvider {
+export class CodeQueryDataProviderService extends QueryDataProvider {
   valueSeparator = ",";
   type = QueryDataType.text;
 
@@ -38,25 +37,17 @@ export class CodeQueryDataProviderService implements QueryDataProvider {
     return null;
   }
 
-  stringifyQuery(query: QueryItem<string>): string {
-    if (!query.method || !query.value?.length) {
-      throw new Error("Invalid query.");
-    }
-
-    return (
-      query.method +
-      ":" +
-      query.value.map(v => v.value).join(this.valueSeparator)
-    );
+  protected serializeValue(value: Displayable<string>): string {
+    return value.value;
   }
 
-  async parseQuery(query: string): Promise<QueryItem<string>> {
-    const [method, ...values] = query.split(":");
-    const value = values
-      .join(":")
+  protected async deserializeValues(
+    valueStrings: string,
+  ): Promise<Displayable<string>[]> {
+    const values = valueStrings
       .split(this.valueSeparator)
       .map(v => ({ value: v, label: v }));
 
-    return { key: this.value, method, value };
+    return values;
   }
 }

--- a/src/app/course/_query/query-data-providers/credit-query-data-provider/credit-query-data-provider.service.ts
+++ b/src/app/course/_query/query-data-providers/credit-query-data-provider/credit-query-data-provider.service.ts
@@ -3,12 +3,11 @@ import { Observable } from "rxjs";
 
 import { Displayable } from "../../../../_types/displayable";
 import { QueryDataProvider, QueryDataType } from "../../query-data-provider";
-import { QueryItem } from "../../query-item";
 
 @Injectable({
   providedIn: "root",
 })
-export class CreditQueryDataProviderService implements QueryDataProvider {
+export class CreditQueryDataProviderService extends QueryDataProvider<string> {
   valueSeparator = ",";
   type = QueryDataType.text;
 
@@ -41,25 +40,17 @@ export class CreditQueryDataProviderService implements QueryDataProvider {
     return "只能輸入數字";
   }
 
-  stringifyQuery(query: QueryItem<string>): string {
-    if (!query.method || !query.value?.length) {
-      throw new Error("Invalid query.");
-    }
-
-    return (
-      query.method +
-      ":" +
-      query.value.map(v => v.value).join(this.valueSeparator)
-    );
+  protected serializeValue(value: Displayable<string>): string {
+    return value.value;
   }
 
-  async parseQuery(query: string): Promise<QueryItem<string>> {
-    const [method, ...values] = query.split(":");
-    const value = values
-      .join(":")
+  protected async deserializeValues(
+    valueStrings: string,
+  ): Promise<Displayable<string>[]> {
+    const values = valueStrings
       .split(this.valueSeparator)
       .map(v => ({ value: v, label: v }));
 
-    return { key: this.value, method, value };
+    return values;
   }
 }

--- a/src/app/course/_query/query-data-providers/keyword-query-data-provider/keyword-query-data-provider.service.ts
+++ b/src/app/course/_query/query-data-providers/keyword-query-data-provider/keyword-query-data-provider.service.ts
@@ -3,12 +3,11 @@ import { Observable } from "rxjs";
 
 import { Displayable } from "../../../../_types/displayable";
 import { QueryDataProvider, QueryDataType } from "../../query-data-provider";
-import { QueryItem } from "../../query-item";
 
 @Injectable({
   providedIn: "root",
 })
-export class KeywordQueryDataProviderService implements QueryDataProvider {
+export class KeywordQueryDataProviderService extends QueryDataProvider<string> {
   valueSeparator = " ";
   type = QueryDataType.text;
 
@@ -38,25 +37,17 @@ export class KeywordQueryDataProviderService implements QueryDataProvider {
     return null;
   }
 
-  stringifyQuery(query: QueryItem<string>): string {
-    if (!query.method || !query.value?.length) {
-      throw new Error("Invalid query.");
-    }
-
-    return (
-      query.method +
-      ":" +
-      query.value.map(v => v.value).join(this.valueSeparator)
-    );
+  protected serializeValue(value: Displayable<string>): string {
+    return value.value;
   }
 
-  async parseQuery(query: string): Promise<QueryItem<string>> {
-    const [method, ...values] = query.split(":");
-    const value = values
-      .join(":")
+  protected async deserializeValues(
+    valueStrings: string,
+  ): Promise<Displayable<string>[]> {
+    const values = valueStrings
       .split(this.valueSeparator)
       .map(v => ({ value: v, label: v }));
 
-    return { key: this.value, method, value };
+    return values;
   }
 }

--- a/src/app/course/_query/query-data-providers/place-query-data-provider/place-query-data-provider.service.ts
+++ b/src/app/course/_query/query-data-providers/place-query-data-provider/place-query-data-provider.service.ts
@@ -4,12 +4,11 @@ import { firstValueFrom, map, Observable } from "rxjs";
 import { PlaceApiService } from "../../../../_api/place/place-api.service";
 import { Displayable } from "../../../../_types/displayable";
 import { QueryDataProvider, QueryDataType } from "../../query-data-provider";
-import { QueryItem } from "../../query-item";
 
 @Injectable({
   providedIn: "root",
 })
-export class PlaceQueryDataProviderService implements QueryDataProvider {
+export class PlaceQueryDataProviderService extends QueryDataProvider<string> {
   valueSeparator = ",";
   type = QueryDataType.select;
 
@@ -24,7 +23,9 @@ export class PlaceQueryDataProviderService implements QueryDataProvider {
     },
   ];
 
-  constructor(private placeApiService: PlaceApiService) {}
+  constructor(private placeApiService: PlaceApiService) {
+    super();
+  }
 
   value = "place";
   label = "上課地點";
@@ -65,34 +66,24 @@ export class PlaceQueryDataProviderService implements QueryDataProvider {
     return null;
   }
 
-  stringifyQuery(query: QueryItem<string>): string {
-    if (!query.method || !query.value?.length) {
-      throw new Error("Invalid query.");
-    }
-
-    return (
-      query.method +
-      ":" +
-      query.value.map(v => v.value).join(this.valueSeparator)
-    );
+  protected serializeValue(value: Displayable<string>): string {
+    return value.value;
   }
 
-  async parseQuery(query: string): Promise<QueryItem<string>> {
-    const [method, ...values] = query.split(":");
-    const value = values
-      .join(":")
-      .split(this.valueSeparator)
-      .map(async v => {
-        const host = await firstValueFrom(
-          this.placeApiService.get(v).pipe(map(response => response.content)),
-        );
+  protected async deserializeValues(
+    valueStrings: string,
+  ): Promise<Displayable<string>[]> {
+    const values = valueStrings.split(this.valueSeparator).map(async v => {
+      const host = await firstValueFrom(
+        this.placeApiService.get(v).pipe(map(response => response.content)),
+      );
 
-        return {
-          value: host.uuid,
-          label: host.name,
-        };
-      });
+      return {
+        value: host.uuid,
+        label: host.name,
+      };
+    });
 
-    return { key: this.value, method, value: await Promise.all(value) };
+    return await Promise.all(values);
   }
 }

--- a/src/app/course/course-search/course-search.component.ts
+++ b/src/app/course/course-search/course-search.component.ts
@@ -17,7 +17,7 @@ export class CourseSearchComponent implements OnInit {
   ngOnInit() {
     this.courseQueryManagerService.getQueries().subscribe(queries => {
       this.queries = queries;
-      this.queryParams = this.courseQueryManagerService.convertToQueryParams();
+      this.queryParams = this.courseQueryManagerService.serializeQueries();
       if (!queries.length || queries[queries.length - 1].key)
         this.courseQueryManagerService.addQuery();
     });

--- a/src/app/course/course.component.ts
+++ b/src/app/course/course.component.ts
@@ -18,25 +18,12 @@ export class CourseComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
-    this.route.queryParamMap.subscribe(params => {
-      this.courseQueryService.clearQueries();
-      const providers = this.courseQueryService.getProviders();
-      const queryParsers = providers.map(displayable => {
-        const provider = this.courseQueryService.getProvider(displayable.value);
-        if (!provider) return;
-        const values = params.getAll(displayable.value);
-
-        const queryParsers = values.map(async value => {
-          this.courseQueryService.addQuery(await provider.parseQuery(value));
-          this.searching = true;
-        });
-        return Promise.all(queryParsers);
-      });
-
-      Promise.all(queryParsers).then(() => {
-        this.loading = false;
-        if (this.searching) this.courseQueryService.removeEmptyQueries();
-      });
+    this.route.queryParamMap.subscribe(async params => {
+      this.loading = true;
+      this.searching = false;
+      const queries = await this.courseQueryService.deserializeQueries(params);
+      this.loading = false;
+      if (queries.length > 1) this.searching = true;
     });
   }
 }


### PR DESCRIPTION
This PR contains following changes:

- Split out logics of queries deserialization from controller of `CourseComponent` and merge it into `CourseQueryService` to go with serialization logics. (9a1377e)
- Make logics of serialization/deserialization abstract from implements of `QueryDataProvider` into it, only value serialization and deserialization needs to be implemented by child classes. This also make `QueryDataProvider` transformed from interface to abstract class. (e21967d)
- Rename `stringify` and `parse` to `serialize` and `deserialize`. (cbd2b50)

This make their responsibility more clear, and make it more convenient to change some logics later.

Note: This PR contains changes in #11, it's recommended to review this PR after #11 is being merged, if #11 has not been merged yet, you may see additional changes in this PR. Or you can select commits 97338f5...cbd2b50 [in PR viewer to see changes in this PR](https://github.com/charkchalk/frontend/pull/12/files/97338f596e650f5a0e3d5225c62387af2d28e7c3..cbd2b506f2fa6c8f65d9474585e0c73d50cb87e0).
