### PR TITLE
fix(ci): auto create pages project

### DIFF
--- a/.github/workflows/ci-preview-cleanup.yml
+++ b/.github/workflows/ci-preview-cleanup.yml
@@ -13,6 +13,6 @@ jobs:
       - name: Revoke Preview Deployment
         run: |
           curl --fail --request DELETE \
-            --url https://api.cloudflare.com/client/v4/accounts/${{ secrets.CLOUDFLARE_ACCOUNT_ID }}/pages/projects/charkchalk-dev-pr-${{ github.event.number }} \
+            --url https://api.cloudflare.com/client/v4/accounts/${{ secrets.CLOUDFLARE_ACCOUNT_ID }}/pages/projects/charkchalk-pr-${{ github.event.number }} \
             --header 'Content-Type: application/json' \
             --header 'Authorization: Bearer ${{ secrets.CLOUDFLARE_PAGES_DEPLOY_TOKEN }}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,17 @@ jobs:
           value: ${{ github.sha }}
           length_from_start: 7
 
+      - name: Create Cloudflare Pages Project
+        run: |
+          curl --request POST \
+            --url https://api.cloudflare.com/client/v4/accounts/${{ secrets.CLOUDFLARE_ACCOUNT_ID }}/pages/projects \
+            --header 'Content-Type: application/json' \
+            --header 'Authorization: Bearer ${{ secrets.CLOUDFLARE_PAGES_DEPLOY_TOKEN }}' \
+            --data '{
+              "name": "charkchalk-pr-${{ github.event.number }}",
+              "production_branch": "main"
+            }'
+
       - name: Deploy Preview to Cloudflare Pages
         id: deployment
         uses: cloudflare/pages-action@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,7 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_PAGES_DEPLOY_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          projectName: charkchalk-dev-pr-${{ github.event.number }}
+          projectName: charkchalk-pr-${{ github.event.number }}
           directory: dist/charkchalk-frontend
           branch: ${{ steps.sha.outputs.substring }}
 


### PR DESCRIPTION
Currently the CI flow does not contains auto create pages project step, I have to manually add a new project before open a new PR. This PR brings automatic pages project creation.

This PR also rename project naming rule from `charkchalk-dev-pr-${{ github.event.number }}` to `charkchalk-pr-${{ github.event.number }}`, removed unnecessary word. 
